### PR TITLE
Add wait.sh and copy.sh

### DIFF
--- a/scripts/copy.sh
+++ b/scripts/copy.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Copyright (c) 2023, Viasat, Inc
+# Licensed under MPL 2.0
+
+# Add files from SRC_DIR to DST_DIR with string interpolation.
+# Any '{{FOO}}' tokens are replaced with value of corresponding
+# environment variable FOO (but only if defined).
+
+die() { local ret=${1}; shift; echo >&2 "${*}"; exit $ret; }
+
+case "${1}" in -T|--template) TEMPLATE=1; shift ;; esac
+
+src_dir="${1}"; shift || die 2 "Usage: ${0} [-T|--template] SRC_DIR DST_DIR"
+dst_dir="${1}"; shift || die 2 "Usage: ${0} [-T|--template] SRC_DIR DST_DIR"
+[ "${1}" = "--" ] && shift
+
+[ -d "${src_dir}" ] || die 2 "Not a directory: '${src_dir}'"
+[ -d "${dst_dir}" ] || die 2 "Not a directory: '${dst_dir}'"
+
+(cd "${src_dir}" && find . -type f) | while read src_file; do
+  src="${src_dir}/${src_file}"
+  dst="${dst_dir}/${src_file}"
+  mkdir -p $(dirname "${dst}") || die 1 "Failed to make target directory"
+  echo cp -a "${src}" "${dst}"
+  cp -a "${src}" "${dst}" || die 1 "Failed to copy file"
+  # TODO: make this configurable
+  chown root.root "${dst}" || die 1 "Unable to set ownership"
+
+  [ -z "${TEMPLATE}" ] && continue
+
+  # match all {{FOO}} style variables and replace from environment
+  for v in $(cat "${dst}" | grep -o '{{[^ }{]*}}' | sed 's/[}{]//g' | sort -u); do
+    if set | grep -qs "^${v}="; then
+      val=$(set | grep "^${v}=" | cut -f 2 -d '=' \
+          | sed "s/^['\"]\(.*\)['\"]$/\1/" \
+          | sed 's/[\/&]/\\&/g')
+      echo "Replacing '{{${v}}}' with '${val}' in '${dst}'"
+      sed -i "s/{{${v}}}/${val}/g" "${dst}"
+    fi
+  done
+done
+
+if [ "${*}" ]; then
+    exec "${@}"
+else
+    true
+fi

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# Copyright (c) 2023, Viasat, Inc
+# Licensed under MPL 2.0
+
+die() { local ret=${1}; shift; echo >&2 "${*}"; exit $ret; }
+
+NC=$(command -v nc 2>/dev/null)
+SOCAT=$(command -v socat 2>/dev/null)
+BASH=$(command -v bash 2>/dev/null)
+WAIT_SLEEP=${WAIT_SLEEP:-1}
+
+do_sleep() {
+  echo "Failed: '${typ} ${arg}'. Sleep ${WAIT_SLEEP} seconds before retry"
+  sleep ${WAIT_SLEEP}
+}
+check_tcp() {
+  if   [ "${NC}" ];    then ${NC} -z -w 1 ${1} ${2} > /dev/null
+  elif [ "${SOCAT}" ]; then ${SOCAT} /dev/null TCP:${1}:${2},connect-timeout=2
+  elif [ "${BASH}" ];  then timeout 1 ${BASH} -c "echo > /dev/tcp/${1}/${2}"
+  else die 1 "Could not find nc, socat, or bash"
+  fi
+}
+
+while [ "${*}" ]; do
+  typ="${1}"; shift
+  arg="${1}"
+  [ "${arg}" = "--" ] && die 2 "No arg found for type '${typ}'"
+  case "${typ}" in
+    --) break; ;;
+    -f|--file)
+      while [ ! -e "${arg}" ]; do do_sleep; done
+      echo "File '${arg}' exists"
+      ;;
+    -i|--if|--intf)
+      while [ ! -e /sys/class/net/${arg}/ifindex ]; do do_sleep; done
+      echo "Interface '${arg}' exists"
+      ;;
+    -I|--ip)
+      while ! grep -qs "^${arg}\>" /proc/net/route; do do_sleep; done
+      echo "Interface '${arg}' has IP/routing"
+      ;;
+    -t|--tcp)
+      host=${arg%:*}
+      port=${arg##*:}
+      [ "${host}" -a "${port}" ] || die 2 "Illegal host/port '${arg}'"
+      while ! check_tcp ${host} ${port}; do do_sleep; done
+      echo "TCP listener is reachable at '${arg}' "
+      ;;
+    -u|--umask)
+      umask ${arg}
+      echo "Set umask to ${arg}"
+      ;;
+    -c|--cmd|--command)
+      while ! ${arg}; do do_sleep; done
+      echo "Command successful: ${arg}"
+      ;;
+    -s|--sleep)
+      WAIT_SLEEP=${arg}
+      echo "Changed WAIT_SLEEP from ${WAIT_SLEEP} to ${arg}"
+      ;;
+    *)
+      echo "Unknown option: ${typ}"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ "${*}" ]; then
+  echo "Running: ${*}"
+  exec ${*}
+fi


### PR DESCRIPTION
Adding two scripts that are useful in conlink setups, when defining
services' commands:

* wait.sh: delay running a subsequent command until a condition is met
           ex: wait for a file or interface to appear
* copy.sh: copy a file(s) to a new location, replaces any templated `{{VAR}}`
           found with the equivalent VAR value from the environment

Example:

```
services:
  h1:
    image: alpine
    network_mode: none
    environment:
      - MY_CONFIG_VAR=3
    volumes:
      - ./scripts/:/scripts:ro
      - ./some/path/files:/files:ro
    # copy /files to / (-T replaces any `{{MY_CONFIG_VAR}}` copied files with `3`)
    # then wait for the interface ctrl0 to appear
    # then run /init.sh
    command: /scripts/copy.sh -T /files / -- /scripts/wait.sh -I ctrl0 -- /init.sh
```