### PR TITLE
Auto bridge mode and misc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM node:16-slim as run
 RUN apt-get -y update
 # Runtime deps and utilities
 RUN apt-get -y install libpcap-dev tcpdump iproute2 iputils-ping curl \
-                       iptables \
+                       iptables bridge-utils \
                        openvswitch-switch openvswitch-testcontroller
 
 COPY --from=build /app/ /app/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # conlink: Declarative Low-Level Networking for Containers
 
+
 Create (layer 2 and layer 3) networking between containers using
 a declarative configuration.
 
@@ -33,6 +34,18 @@ what the other containers require then those additional capabilities
 will also be required for the conlink container. In particular, if the
 container uses systemd, then it will likely use `SYS_NICE` and
 `NET_BROADCAST` and conlink will likewise need those capabilities.
+
+### Bridging: Open vSwtich/OVS or Linux bridge
+
+Conlink creates bridges/switches and connects veth container links to
+those bridges (specified by `bridge:` in the link specification).
+By default, conlink will attempt to create Open vSwitch/OVS bridges
+for these connections, however, if the kernel does not provide support
+(`openvswitch` kernel module loaded), then conlink will fallback to
+using standard Linux bridges. The fallback behavior can be changed by
+setting the `--bridge-mode` option to either "ovs" or "linux". If the
+bridge mode is set to "ovs" then conlink will fail to start if the
+`openvswitch` kernel module is not detected.
 
 ## Network Configuration Syntax
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ The following table describes the link properties:
 | route     | *          | string     |         | ip route add args        |
 | nat       | *          | IP         |         | DNAT/SNAT to IP          |
 | netem     | *          | string     |         | tc qdisc NetEm options   |
-| mode      | 5          | IP         |         | virt intf mode           |
-| vlanid    | vlan       | IP         |         | VLAN ID                  |
+| mode      | 5          | string     |         | virt intf mode           |
+| vlanid    | vlan       | number     |         | VLAN ID                  |
 
 - 1 - veth, dummy, vlan, ipvlan, macvlan, ipvtap, macvtap
 - 2 - defaults to outer compose service
@@ -261,7 +261,7 @@ defined in the first compose file.
 MODES_DIR=./examples/test4-multiple/modes ./mdc node1 up --build --force-recreate
 ```
 
-Ping the router host from `node`:
+Ping the router host from `node1`:
 
 ```
 docker-compose exec node1 ping 10.0.0.100

--- a/README.md
+++ b/README.md
@@ -6,10 +6,19 @@ a declarative configuration.
 
 ## Prerequisites
 
+General:
+* docker
 * docker-compose version 1.25.4 or later.
-* `openvswitch` kernel module loaded on the host
-* `geneve` (and/or `vxlan`) kernel module loaded on the host (only
-  needed for `test5-geneve-compose` example)
+
+Other:
+* For Open vSwtich (OVS) bridging, the `openvswitch` kernel module
+  must loaded on the host system (where docker engine is running).
+* For podman usage (e.g. second part of `test3`), podman is required.
+* For remote connections/links (e.g. `test5`), the `geneve` (and/or
+  `vxlan`) kernel module must be loaded on the host system (where
+  docker engine is running)
+* For CloudFormation deployment (e.g. `test6`), the AWS CLI is
+  required.
 
 ## Usage Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Support a new "auto" value for --bridge-mode. This will automatically fall back to linux bridging if openvswitch/ovs is not available. "auto" becomes the new default and the `CONLINK_BRIDGE_MODE` environment variable is added to change the mode via environment.

This simplifies things (and reduces the dep list) for cases where users don't actually need ovs functionality. The README is updated to note the simplified prerequisitese (which are only docker and docker-compose when not using ovs or geneve/vxlan functionality.

NOTE: in the future if we add ovs flows/rules to the configuration then we'll need to check for the use of those and check that we aren't in or falling back to linux bridging.