### PR TITLE
Bridge mode per link, new patch "bridge" mode, misc, bump version to 2.1.0

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
         run: npm install
 
       - name: compose build of conlink
-        run: docker-compose -f examples/test1-compose.yaml build
+        run: docker compose -f examples/test1-compose.yaml build
 
       - name: "./run-tests.sh"
         timeout-minutes: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get -y install libpcap-dev tcpdump iproute2 iputils-ping curl \
                        openvswitch-switch openvswitch-testcontroller
 
 COPY --from=build /app/ /app/
-ADD link-add.sh link-del.sh /app/
+ADD link-add.sh link-del.sh link-mirred.sh /app/
 ADD schema.yaml /app/build/
 
 ENV PATH /app:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM node:16-slim as run
 RUN apt-get -y update
 # Runtime deps and utilities
 RUN apt-get -y install libpcap-dev tcpdump iproute2 iputils-ping curl \
-                       iptables bridge-utils \
+                       iptables bridge-utils ethtool \
                        openvswitch-switch openvswitch-testcontroller
 
 COPY --from=build /app/ /app/

--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ container uses systemd, then it will likely use `SYS_NICE` and
 ### Bridging: Open vSwtich/OVS or Linux bridge
 
 Conlink creates bridges/switches and connects veth container links to
-those bridges (specified by `bridge:` in the link specification).
-By default, conlink will attempt to create Open vSwitch/OVS bridges
-for these connections, however, if the kernel does not provide support
-(`openvswitch` kernel module loaded), then conlink will fallback to
-using standard Linux bridges. The fallback behavior can be changed by
-setting the `--bridge-mode` option to either "ovs" or "linux". If the
-bridge mode is set to "ovs" then conlink will fail to start if the
-`openvswitch` kernel module is not detected.
+a bridge (specified by `bridge:` in the link specification). The
+default bridge mode is defined by the `--default-bridge-mode`
+parameter and defaults to "auto". If a bridge is set to mode "auto"
+then conlink will check if the kernel has the `openvswitch` kernel
+module loaded and if so it will create an Open vSwitch/OVS
+bridge/switch for that bridge, otherwise it will create a regular
+Linux bridge (e.g. brctl). If any bridges are explicitly defined with
+an "ovs" mode and the kernel does not have support then conlink will
+stop/error on startup.
 
 ## Network Configuration Syntax
 
@@ -121,6 +122,21 @@ than the MTU of the parent (outer-dev) device.
 
 For the `netem` property, refer to the `netem` man page. The `OPTIONS`
 grammar defines the valid strings for the `netem` property.
+
+### Bridges
+
+The bridge settings currently only support the "mode" setting. If
+the mode is not specified in this section or the section is omitted
+entirely, then bridges specified in the links configuration will
+default to the value of the `--default-bridge-mode` parameter (which
+itself defaults to "auto").
+
+The following table describes the bridge properties:
+
+| property  | format  | description                    |
+|-----------|---------|--------------------------------|
+| bridge    | string  | conlink bridge / domain name   |
+| mode      | string  | auto, ovs, or linux            |
 
 ### Tunnels
 
@@ -475,6 +491,19 @@ curl 192.168.0.32
 Note: to connect to the vlan node (NODE2_HOST_ADDRESS) you will need
 to configure your physical switch/router with routing/connectivity to
 VLAN 5 on the same physical link to your host.
+
+### test9: bridge modes
+
+This example demonstrates the supported bridge modes.
+
+Start the test9 compose configuration using different bridge modes and
+validate connectivity using ping:
+
+```
+export BRIDGE_MODE="linux"  # "ovs", "auto"
+docker-compose -f examples/test9-compose.yaml up --build --force-recreate
+docker-compose -f examples/test9-compose.yaml exec node ping 10.0.1.2
+```
 
 ## GraphViz network configuration rendering
 

--- a/examples/test9-compose.yaml
+++ b/examples/test9-compose.yaml
@@ -30,4 +30,3 @@ x-network:
     - {bridge: s1, service: node, ip: 10.0.1.1/24}
   bridges:
     - {bridge: s1, mode: "${BRIDGE_MODE:-auto}"}
-

--- a/examples/test9-compose.yaml
+++ b/examples/test9-compose.yaml
@@ -1,0 +1,33 @@
+# This file demonstrates using different bridge modes and
+# usage of the --default-brige-mode parameter.
+
+version: "2.4"
+
+services:
+  network:
+    build: {context: ../}
+    image: conlink
+    pid: host
+    network_mode: none
+    cap_add: [SYS_ADMIN, NET_ADMIN, SYS_NICE, NET_BROADCAST, IPC_LOCK]
+    security_opt: [ 'apparmor:unconfined' ] # needed on Ubuntu 18.04
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker:/var/lib/docker
+      - ./:/test
+    environment:
+      - BRIDGE_MODE
+    command: /app/build/conlink.js --default-bridge-mode linux --compose-file /test/test9-compose.yaml
+
+  node:
+    image: alpine
+    network_mode: none
+    scale: 2
+    command: sleep Infinity
+
+x-network:
+  links:
+    - {bridge: s1, service: node, ip: 10.0.1.1/24}
+  bridges:
+    - {bridge: s1, mode: "${BRIDGE_MODE:-auto}"}
+

--- a/link-mirred.sh
+++ b/link-mirred.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Copyright (c) 2024, Equinix, Inc
+# Licensed under MPL 2.0
+
+set -e
+
+usage () {
+  echo >&2 "${0} [OPTIONS] INTF0 INTF1"
+  echo >&2 ""
+  echo >&2 "Create traffic mirror/redirect between INTF0 and INTF1."
+  echo >&2 ""
+  echo >&2 "Positional arguments:"
+  echo >&2 "  INTF0 is the first interface name"
+  echo >&2 "  INTF1 is the second interface name"
+  echo >&2 ""
+  echo >&2 "INTF0 must exist, but if INTF1 is missing, then exit with 0."
+  echo >&2 "Each interface will be checked for correct ingress/mirred config"
+  echo >&2 "and configured if the configuration is missing."
+  echo >&2 "These two aspect make this script idempotent. It can be called"
+  echo >&2 "whenever either interface appears and when the second appears,"
+  echo >&2 "the mirror/redirect action will be setup fully/bidirectionally."
+  echo >&2 ""
+  echo >&2 "OPTIONS:"
+  echo >&2 "  --verbose                - Verbose output (set -x)"
+  exit 2
+}
+
+info() { echo "link-mirred [${LOG_ID}] ${*}"; }
+warn() { >&2 echo "link-mirred [${LOG_ID}] ${*}"; }
+die()  { warn "ERROR: ${*}"; exit 1; }
+
+# Idempotently add ingress qdisc to an interface
+add_ingress() {
+  local IF=$1 res=
+
+  res=$(tc qdisc show dev ${IF} 2>&1)
+  case "${res}" in
+    *"qdisc ingress ffff:"*)
+      info "${IF0} already has ingress qdisc"
+      ;;
+    ""|*"qdisc noqueue"*)
+      info "Adding ingress qdisc to ${IF}"
+      tc qdisc add dev "${IF}" ingress \
+        || die "Could not add ingress qdisc to ${IF}"
+      ;;
+    *)
+      die "${IF} has invalid ingress qdisc or could not be queried"
+      ;;
+  esac
+}
+
+# Idempotently add mirred filter redirect rule to an interface
+add_mirred() {
+  local IF0=$1 IF1=$2 res=
+
+  res=$(tc filter show dev ${IF0} parent ffff: 2>&1)
+  case "${res}" in
+    *"action order 1: mirred (Egress Redirect to device ${IF1}"*)
+      info "${IF0} already has filter redirect action"
+      ;;
+    "")
+      info "Adding filter redirect action from ${IF0} to ${IF1}"
+      tc filter add dev ${IF0} parent ffff: protocol all u32 match u8 0 0 action \
+        mirred egress redirect dev ${IF1} \
+        || die "Could not add filter redirect action from ${IF0} to ${IF1}"
+      ;;
+    *)
+      die "${IF0} has invalid filter redirect action or could not be queried"
+      ;;
+  esac
+}
+
+# Parse arguments
+VERBOSE=${VERBOSE:-}
+positional=
+while [ "${*}" ]; do
+  param=$1; OPTARG=$2
+  case ${param} in
+  --verbose)        VERBOSE=1 ;;
+  -h|--help)        usage ;;
+  *)                positional="${positional} $1" ;;
+  esac
+  shift
+done
+set -- ${positional}
+IF0=$1 IF1=$2
+
+[ "${VERBOSE}" ] && set -x || true
+
+# Sanity check arguments
+[ "${IF0}" -a "${IF1}" ] || usage
+
+LOG_ID="mirred ${IF0}:${IF1}"
+
+# Sanity checks
+if ! ip link show ${IF0} >/dev/null; then
+  die "${IF0} does not exist"
+fi
+if ! ip link show ${IF1} >/dev/null; then
+  info "${IF1} missing, exiting"
+  exit 0
+fi
+
+### Do the work
+
+info "Creating filter rediction action between ${IF0} and ${IF1}"
+
+add_ingress ${IF0}
+add_ingress ${IF1}
+add_mirred ${IF0} ${IF1}
+add_mirred ${IF1} ${IF0}
+
+info "Created filter rediction action between ${IF0} and ${IF1}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -134,6 +134,26 @@ echo " >> Check for round-trip ping delay of 80ms"
 dc_test node_1 'ping -c2 10.0.1.2 | tail -n1 | grep "max = 80\."'
 
 
+echo -e "\n\n>>> test9: bridge modes and variable templating"
+echo "COMPOSE_FILE=examples/test9-compose.yaml" > .env
+
+echo -e "\n\n >> test9: bridge mode: auto"
+GROUP=test9-auto
+export BRIDGE_MODE=auto
+dc_init; dc_wait 10 node_1 'ip addr | grep "10\.0\.1\.1"' \
+    || die "test9 (auto) startup failed"
+echo " >> Check for round-trip ping connectivity (BRIDGE_MODE=auto)"
+dc_test node_1 'ping -c2 10.0.1.2'
+
+echo -e "\n\n >> test9: bridge mode: linux"
+GROUP=test9-linux
+export BRIDGE_MODE=linux
+dc_init; dc_wait 10 node_1 'ip addr | grep "10\.0\.1\.1"' \
+    || die "test9 (linux) startup failed"
+echo " >> Check for round-trip ping connectivity (BRIDGE_MODE=linux)"
+dc_test node_1 'ping -c2 10.0.1.2'
+
+
 echo -e "\n\n>>> Cleaning up"
 dc down -t1 --remove-orphans
 rm -f .env

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -153,6 +153,16 @@ dc_init; dc_wait 10 node_1 'ip addr | grep "10\.0\.1\.1"' \
 echo " >> Check for round-trip ping connectivity (BRIDGE_MODE=linux)"
 dc_test node_1 'ping -c2 10.0.1.2'
 
+echo -e "\n\n >> test9: bridge mode: patch"
+GROUP=test9-patch
+export BRIDGE_MODE=patch
+dc_init; dc_wait 10 node_1 'ip addr | grep "10\.0\.1\.1"' \
+    || die "test9 startup failed"
+echo " >> Ensure ingest filter rules exist (BRIDGE_MODE=patch)"
+dc_test network 'tc filter show dev node_1-eth0 parent ffff: | grep "action order 1: mirred"'
+echo " >> Check for round-trip ping connectivity (BRIDGE_MODE=patch)"
+dc_test node_1 'ping -c2 10.0.1.2'
+
 
 echo -e "\n\n>>> Cleaning up"
 dc down -t1 --remove-orphans

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,8 +9,15 @@ declare FAIL=0
 
 die() { echo >&2 "${*}"; exit 1; }
 vecho() { [ "${VERBOSE}" ] && echo "${*}" || true; }
-dc() { docker-compose "${@}"; }
+dc() { ${DOCKER_COMPOSE} "${@}"; }
 mdc() { ./mdc "${@}" || die "mdc invocation failed"; }
+
+# Determine compose command
+for dc in "docker compose" "docker-compose"; do
+  ${dc} version 2>/dev/null >&2 && DOCKER_COMPOSE="${dc}" && break
+done
+[ "${DOCKER_COMPOSE}" ] || die "No compose command found"
+echo >&2 "Using compose command '${DOCKER_COMPOSE}'"
 
 dc_init() {
   local cont="${1}" idx="${2}"

--- a/schema.yaml
+++ b/schema.yaml
@@ -46,6 +46,13 @@ properties:
         mode:      {type: string}
         vlanid:    {type: number}
 
+  bridges:
+    type: array
+    items:
+      type: object
+      properties:
+        mode: {type: string, enum: [auto, ovs, linux]}
+
   tunnels:
     type: array
     items:

--- a/schema.yaml
+++ b/schema.yaml
@@ -51,7 +51,7 @@ properties:
     items:
       type: object
       properties:
-        mode: {type: string, enum: [auto, ovs, linux]}
+        mode: {type: string, enum: [auto, ovs, linux, patch]}
 
   tunnels:
     type: array

--- a/src/conlink/core.cljs
+++ b/src/conlink/core.cljs
@@ -27,7 +27,7 @@ General Options:
   -v, --verbose                     Show verbose output (stderr)
                                     [env: VERBOSE]
   --show-config                     Print loaded network config JSON and exit
-  --default-bridge-mode BRIDGE-MODE Default bridge mode (ovs, linux, or auto)
+  --default-bridge-mode BRIDGE-MODE Default bridge mode (ovs, linux, patch, or auto)
                                     to use for bridge/switch connections
                                     [default: auto] [env: CONLINK_BRIDGE_MODE]
   --network-file NETWORK-FILE...    Network config file
@@ -62,7 +62,8 @@ General Options:
                 :warn         #(apply Eprintln "WARNING:" %&)
                 :log          Eprintln
                 :info         #(identity nil)
-                :kmod-ovs?    false}))
+                :kmod-ovs?    false
+                :kmod-mirred? false}))
 
 ;; Simple utility functions
 (defn json-str [obj]
@@ -121,13 +122,18 @@ General Options:
 (defn enrich-bridge
   "If bridge mode is :auto then return :ovs if the 'openvswitch' kernel module
   is loaded otherwise fall back to :linux. Exit with an error if mode is :ovs
-  and the 'openvswitch' kernel module is not loaded."
+  or :patch and the 'openvswitch' or 'act_mirred' kernel modules are not
+  loaded respectively."
   [{:as bridge-opts :keys [bridge mode]}]
-  (let [{:keys [warn default-bridge-mode kmod-ovs?]} @ctx
+  (let [{:keys [warn default-bridge-mode kmod-ovs? kmod-mirred?]} @ctx
         mode (keyword (or mode default-bridge-mode))
         _ (when (and (= :ovs mode) (not kmod-ovs?))
             (fatal 1 (str "bridge " bridge " mode is 'ovs', "
                           "but no 'openvswitch' kernel module loaded")))
+        _ (when (and (= :patch mode) (not kmod-mirred?))
+            (warn (str "bridge " bridge " mode is 'patch', "
+                       "but no 'act_mirred' kernel module loaded, "
+                       " assuming it will load when needed.")))
         _ (when (and (= :auto mode) (not kmod-ovs?))
             (warn (str "bridge " bridge " mode is 'auto', "
                        " but no 'openvswitch' kernel module loaded, "
@@ -345,7 +351,8 @@ General Options:
   [{:keys [bridge mode]}]
   (P/let [{:keys [info]} @ctx
           cmd (get {:ovs (str "ovs-vsctl list-ifaces " bridge)
-                    :linux (str "ip link show type bridge " bridge)}
+                    :linux (str "ip link show type bridge " bridge)
+                    :patch nil}
                    mode)]
     (if (not cmd)
       true
@@ -364,7 +371,8 @@ General Options:
   [{:keys [bridge mode]}]
   (P/let [{:keys [info error]} @ctx
           cmd (get {:ovs (str "ovs-vsctl add-br " bridge)
-                    :linux (str "ip link add " bridge " up type bridge")}
+                    :linux (str "ip link add " bridge " up type bridge")
+                    :patch nil}
                    mode)]
     (if (not cmd)
       (info (str "Ignoring bridge/switch " bridge " for mode " mode))
@@ -381,7 +389,8 @@ General Options:
   [{:keys [bridge mode]}]
   (P/let [{:keys [info error]} @ctx
           cmd (get {:ovs (str "ovs-vsctl del-br " bridge)
-                    :linux (str "ip link del " bridge)} mode)]
+                    :linux (str "ip link del " bridge)
+                    :patch nil} mode)]
     (if (not cmd)
       (info (str "Ignoring bridge/switch " bridge " for mode " mode))
       (P/let [_ (info "Deleting bridge/switch" bridge)
@@ -417,7 +426,41 @@ General Options:
       (swap! ctx update-in [:network-state :bridges bridge :links] disj dev)
       (error (str "Unable to drop link " dev " from " bridge)))))
 
+(defn patch-add-link
+  "Setup patch between 'dev' and its peer link using tc qdisc mirred
+  filter action. Peer links are tracked in pseudo-bridge 'bridge'."
+  [{:keys [bridge mode]} dev]
+  (let [{:keys [info error]} @ctx
+        links-path [:network-state :bridges bridge :links]
+        links (get-in @ctx links-path)
+        peers (disj links dev)]
+    (condp = (count peers)
+      0
+      (P/do
+        (info (str "Registering first peer link "
+                   dev " in :patch 'bridge' " bridge))
+        (swap! ctx update-in links-path conj dev))
 
+      1
+      (P/let [cmd (str "link-mirred.sh " dev " " (first peers))
+              res (run cmd)]
+        (if (= 0 (:code res))
+          (swap! ctx update-in links-path conj dev)
+          (error (str "Failed to setup tc filter action for "
+                      dev " in :patch 'bridge' " bridge))))
+
+      (error "Cannot add third peer link "
+             dev " to :patch 'bridge' " bridge))))
+
+(defn patch-drop-link
+  "Remove tracking of 'dev' from pseudo-bridge 'bridge'."
+  [{:keys [bridge mode]} dev]
+  (let [{:keys [info error]} @ctx
+        links-path [:network-state :bridges bridge :links]]
+    (info (str "Removing peer link "
+               dev " from :patch 'bridge' " bridge))
+    ;; State is in the links, no extra cleanup
+    (swap! ctx update-in links-path conj dev)))
 
 ;;; Link commands
 
@@ -566,7 +609,10 @@ General Options:
         (P/do
           (swap! ctx assoc-in status-path :creating)
           (link-add link)
-          (when bridge (bridge-add-link bridge outer-dev))
+          (when bridge
+            (if (= :patch (:mode bridge))
+              (patch-add-link bridge outer-dev)
+              (bridge-add-link bridge outer-dev)))
           (swap! ctx assoc-in status-path :created)))
 
       "die"
@@ -574,7 +620,10 @@ General Options:
         (error (str "Link " dev-id " does not exist"))
         (P/do
           (swap! ctx assoc-in status-path :deleting)
-          (when bridge (bridge-drop-link bridge outer-dev))
+          (when bridge
+            (if (= :patch (:mode bridge))
+              (patch-drop-link bridge outer-dev)
+              (bridge-drop-link bridge outer-dev)))
           (link-del link)
           (swap! ctx assoc-in status-path nil))))))
 
@@ -730,8 +779,10 @@ General Options:
      self-pid js/process.pid
      schema (load-config (:config-schema opts))
      kmod-ovs? (kmod-loaded? "openvswitch")
+     kmod-mirred? (kmod-loaded? "act_mirred")
      _ (swap! ctx merge {:default-bridge-mode (:default-bridge-mode opts)
-                         :kmod-ovs? kmod-ovs?})
+                         :kmod-ovs? kmod-ovs?
+                         :kmod-mirred? kmod-mirred?})
      network-config (P/-> (load-configs compose-file network-file)
                           (interpolate-walk env)
                           (check-schema schema verbose)


### PR DESCRIPTION
- Add ethtool to conlink container Dockerfile (sometimes needed for looking at lower-level interface configs)
- Configure bridge mode on a per link/bridge basis (instead of globally)
- Add new "patch" bridge mode that uses tc qdisc mirred filtering to create essentially a patch cable (bump-in-the-wire)
- Bump version to 2.1.0 (minor version change due to backwards compatible schema/functionality change)