### PR TITLE
Add --default-mtu. Change default to 65535 (from 9000).

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The following table describes the link properties:
 | dev       | *          | string[15] | eth0    | container intf name      |
 | ip        | *          | CIDR       |         | IP CIDR (index offset)   |
 | mac       | 3          | MAC        |         | MAC addr (index offset)  |
-| mtu       | *          | number 4   | 9000    | intf MTU                 |
+| mtu       | *          | number 4   | 65535   | intf MTU                 |
 | route     | *          | string     |         | ip route add args        |
 | nat       | *          | IP         |         | DNAT/SNAT to IP          |
 | netem     | *          | string     |         | tc qdisc NetEm options   |
@@ -449,8 +449,10 @@ Start the test7 compose configuration:
 docker-compose -f examples/test7-compose.yaml up --build --force-recreate
 ```
 
-Show the links in both node containers to see that the MAC addresses
-are `00:0a:0b:0c:0d:0*` and the MTUs are set to `4111`.
+Show the links in both node containers to see that on the eth0
+interfaces the MAC addresses are `00:0a:0b:0c:0d:0*` and the MTUs are
+set to `4111`. The eth1 interfaces should have the command line set
+default MTU of `5111`.
 
 ```
 docker-compose -f examples/test7-compose.yaml exec --index 1 node ip link

--- a/examples/test7-compose.yaml
+++ b/examples/test7-compose.yaml
@@ -15,7 +15,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker:/var/lib/docker
       - ./:/test
-    command: /app/build/conlink.js --compose-file /test/test7-compose.yaml
+    command: /app/build/conlink.js --default-mtu 5111 --compose-file /test/test7-compose.yaml
 
   node:
     image: alpine
@@ -29,3 +29,6 @@ services:
           mac: 00:0a:0b:0c:0d:01
           mtu: 4111
           netem: "delay 40ms rate 10mbit"
+        - bridge: s2
+          ip: 100.0.1.1/16
+          dev: eth1


### PR DESCRIPTION
MTU of 9000 was an arbitrary jumbo frame size. Setting the default to the max possible is probably the least likely to cause surprises (especially with patch connections).

Add testing of --default-mtu to the test7 example.