### PR TITLE
Add port forwarding support and bump to 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get -y install libpcap-dev tcpdump iproute2 iputils-ping curl \
                        openvswitch-switch openvswitch-testcontroller
 
 COPY --from=build /app/ /app/
-ADD link-add.sh link-del.sh link-mirred.sh /app/
+ADD link-add.sh link-del.sh link-mirred.sh link-forward.sh /app/
 ADD schema.yaml /app/build/
 
 ENV PATH /app:$PATH

--- a/examples/test10-compose.yaml
+++ b/examples/test10-compose.yaml
@@ -1,0 +1,38 @@
+version: "2.4"
+
+services:
+  node1:
+    image: python:3-alpine
+    network_mode: none
+    command: "python3 -m http.server -d /var 80"
+    x-network:
+      links:
+        - {bridge: s2, ip: "10.0.1.1/24", route: "default",
+           forward: ["1080:80/tcp", "1180:80/tcp"]}
+
+  node2:
+    image: python:3-alpine
+    network_mode: none
+    scale: 2
+    command: "python3 -m http.server -d /usr 80"
+    x-network:
+      links:
+        - {bridge: s1, ip: "10.0.2.1/24", route: "default",
+           forward: ["80:80/tcp"]}
+
+  network:
+    build: {context: ../}
+    image: conlink
+    pid: host
+    cap_add: [SYS_ADMIN, NET_ADMIN, SYS_NICE, NET_BROADCAST, IPC_LOCK]
+    security_opt: [ 'apparmor:unconfined' ] # needed on Ubuntu 18.04
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker:/var/lib/docker
+      - ../:/test
+    ports:
+      - "3080:1080/tcp"
+      - "8080:1180/tcp"
+      - "80:80/tcp"
+      - "81:81/tcp"
+    command: /app/build/conlink.js --compose-file /test/examples/test10-compose.yaml

--- a/link-add.sh
+++ b/link-add.sh
@@ -45,6 +45,8 @@ usage () {
   echo >&2 ""
   echo >&2 "  --netem NETEM            - tc qdisc netem OPTIONS (man 8 netem)"
   echo >&2 "  --nat TARGET             - Stateless NAT traffic to/from TARGET"
+  echo >&2 "                             (in primary/PID0 netns)"
+  echo >&2 ""
   exit 2
 }
 

--- a/link-forward.sh
+++ b/link-forward.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright (c) 2024, Equinix, Inc
+# Licensed under MPL 2.0
+
+set -e
+
+usage () {
+  echo >&2 "${0} [OPTIONS] <add|del> INTF_A INTF_B PORT_A:IP:PORT_B/PROTO"
+  echo >&2 ""
+  echo >&2 "Match traffic on INTF_A that has destination port PORT_A and"
+  echo >&2 "protocol PROTO (tcp or udp). Forward/DNAT traffic to IP:PORT_B "
+  echo >&2 "via INTF_B."
+  exit 2
+}
+
+info() { echo "link-forward [${LOG_ID}] ${*}"; }
+
+IPTABLES() {
+  case "${action}" in
+    add) iptables -C "${@}" 2>/dev/null || iptables -I "${@}" ;;
+    del) iptables -D "${@}" 2>/dev/null || true;;
+  esac
+}
+
+action=$1; shift || usage
+intf_a=$1; shift || usage
+intf_b=$1; shift || usage
+spec=$1;   shift || usage
+read port_a ip port_b proto <<< "${spec//[:\/]/ }"
+
+[ "${action}" -a "${intf_a}" -a "${intf_b}" ] || usage
+[ "${port_a}" -a "${ip}" -a "${port_b}" -a "${proto}" ] || usage
+
+LOG_ID="${spec}"
+
+info "${action^} forwarding ${intf_a} -> ${intf_b}"
+
+IPTABLES PREROUTING -t nat -i ${intf_a} -p ${proto} --dport ${port_a} -j DNAT --to-destination ${ip}:${port_b}
+IPTABLES POSTROUTING -t nat -o ${intf_b} -j MASQUERADE
+
+case "${action}" in
+  add) ip route replace ${ip} dev ${intf_b} ;;
+  del) ip route delete ${ip} dev ${intf_b} || true;;
+esac

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -151,8 +151,8 @@ dc_test node_1 'ip link show eth0 | grep "ether 00:0a:0b:0c:0d:01"'
 dc_test node_2 'ip link show eth0 | grep "ether 00:0a:0b:0c:0d:02"'
 dc_test node_1 'ip link show eth0 | grep "mtu 4111"'
 dc_test node_2 'ip link show eth0 | grep "mtu 4111"'
-echo " >> Check for round-trip ping delay of 80ms"
-dc_test node_1 'ping -c2 10.0.1.2 | tail -n1 | grep "max = 80\."'
+echo " >> Check for min round-trip ping delay of about 80ms"
+dc_test node_1 'ping -c5 10.0.1.2 | grep "min/avg/max = 8[012345]\."'
 
 
 echo -e "\n\n>>> test9: bridge modes and variable templating"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -184,6 +184,20 @@ dc_test network 'tc filter show dev node_1-eth0 parent ffff: | grep "action orde
 echo " >> Check for round-trip ping connectivity (BRIDGE_MODE=patch)"
 dc_test node_1 'ping -c2 10.0.1.2'
 
+echo -e "\n\n>>> test10: port forwarding"
+GROUP=test10
+echo "COMPOSE_FILE=examples/test10-compose.yaml" > .env
+
+dc_init; dc_wait 10 node1_1 'ip addr | grep "10\.0\.1\.1"' \
+    || die "test10 startup failed"
+echo " >> Check ping between replicas"
+dc_test node2_1 'ping -c2 10.0.2.2'
+echo " >> Ensure ports are forwarded correctly"
+do_test 10 'curl -s -S "http://0.0.0.0:3080" | grep "log"'
+do_test 10 'curl -s -S "http://0.0.0.0:8080" | grep "log"'
+do_test 10 'curl -s -S "http://0.0.0.0:80" | grep "share"'
+do_test 10 'curl -s -S "http://0.0.0.0:81" | grep "share"'
+
 
 echo -e "\n\n>>> Cleaning up"
 dc down -t1 --remove-orphans

--- a/schema.yaml
+++ b/schema.yaml
@@ -45,6 +45,9 @@ properties:
         netem:     {type: string}
         mode:      {type: string}
         vlanid:    {type: number}
+        forward:
+          type: array
+          items: {type: string, pattern: "^[0-9]{1,5}:[0-9]{1,5}/(tcp|udp)$"}
 
   bridges:
     type: array


### PR DESCRIPTION
Add port forwarding support (conlink -> containers)
- Add new 'forward' link property. This property is an array of strings
  of the form `conlink_port:container_port/proto` similar to docker port
  publishing.
- Add 'link-forward.sh' script that will add (or delete) the iptables
  and route rules to accomplish the port forwarding from one interface
  to an IP on another interface with port remappping (NAT/masquerade).
- Add a test10 example that shows a single forward definition forwarding
  to two container replicas and shows two forward defintions both
  forwarding to a single container service/port.

Also, small refactor in how docker's eth0 interface is detected and renamed (to support port forwarding) and some refactor to run-tests.sh to support tests invocations that are compose exec calls (i.e. curl from the outside to support port forwarding tests).