### PR TITLE
Multiple mode dirs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: npm install
         run: npm install

--- a/mdc
+++ b/mdc
@@ -17,21 +17,18 @@ LS=$(which ls)
 RESOLVE_DEPS="${RESOLVE_DEPS-./node_modules/@lonocloud/resolve-deps/resolve-deps.py}"
 DOCKER_COMPOSE="${DOCKER_COMPOSE:-docker-compose}"
 
-[ -f "${RESOLVE_DEPS}" ] || die "Missing ${RESOLVE_DEPS}. Perhaps 'npm install'?"
+which ${RESOLVE_DEPS} >/dev/null 2>/dev/null \
+  || die "Missing ${RESOLVE_DEPS}. Perhaps 'npm install'?"
+
+# Resolve mode directory paths
+
 MODE_SPEC="${1}"; shift
-if [ "${RESOLVE_DEPS}" ]; then
-    MODES="$(${RESOLVE_DEPS} --path "${MODES_DIR}" ${MODE_SPEC})"
-else
-    MODES="${MODE_SPEC//,/ }"
-fi
+RESOLVED_MODES="$(${RESOLVE_DEPS} --path "${MODES_DIR}" --format=paths ${MODE_SPEC})"
 
-echo >&2 "MODES:    ${MODES}"
-vecho "ENV_FILE: ${ENV_FILE}"
+# Create base (empty) compose file to anchor mode relative paths
+# to the same root directory.  Create files dir.
 
-declare -A FINISHED
 COMPOSE_FILE=./.compose-empty.yaml
-COMPOSE_PROFILES=
-MDC_MODE_DIRS=
 cat /dev/null > ${ENV_FILE}-mdc-tmp
 echo -e "version: '2.4'\nservices: {}" > ./.compose-empty.yaml
 
@@ -42,19 +39,25 @@ esac
 [ -d "${MDC_FILES_DIR}" ] && rm -r${VERBOSE:+v} ${MDC_FILES_DIR}/
 mkdir -p "${MDC_FILES_DIR}"
 
-for mode in ${MODES}; do
+# Incorporate modes' compose config, env, and files
+
+declare -A FINISHED
+COMPOSE_PROFILES=
+MDC_MODE_NAMES=
+MDC_MODE_DIRS=
+for resolved in ${RESOLVED_MODES}; do
+    mode=${resolved%=*}
+    path=${resolved#*=}
+
     # Only process each mode once
     [ "${FINISHED[${mode}]}" ] && continue
     FINISHED["${mode}"]=1
 
-    # mode dir must exist
-    [ -d "${MODES_DIR}/${mode}" ] || \
-        die "No mode dir found for ${mode}"
-
-    MDC_MODE_DIRS="${MDC_MODE_DIRS},${MODES_DIR}/${mode}"
+    MDC_MODE_NAMES="${MDC_MODE_NAMES} ${mode}"
+    MDC_MODE_DIRS="${MDC_MODE_DIRS},${path}"
 
     # mode can refer to a compose file in multiple ways
-    cfiles="${MODES_DIR}/${mode}/compose.yaml ${MODES_DIR}/${mode}/compose.yml ${MODES_DIR}/${mode}/docker-compose.yaml ${MODES_DIR}/${mode}/docker-compose.yml"
+    cfiles="${path}/compose.yaml ${path}/compose.yml ${path}/docker-compose.yaml ${path}/docker-compose.yml"
     for cfile in ${cfiles}; do
         if [ -e "${cfile}" ]; then
             COMPOSE_FILE="${COMPOSE_FILE}:${cfile}"
@@ -66,26 +69,33 @@ for mode in ${MODES}; do
     COMPOSE_PROFILES="${COMPOSE_PROFILES},MODE_${mode}"
 
     # if there is a mode specific env file then include it
-    efiles="${MODES_DIR}/${mode}/env ${MODES_DIR}/${mode}/.env"
+    efiles="${path}/env ${path}/.env"
     for efile in ${efiles}; do
         if [ -e "${efile}" ]; then
-            echo "### mdc begin mode ${mode}" >> ${ENV_FILE}-mdc-tmp
+            echo "### mdc begin mode ${mode} (${efile})" >> ${ENV_FILE}-mdc-tmp
             vecho "cat ${efile} >> ${ENV_FILE}-mdc-tmp"
             cat ${efile} >> ${ENV_FILE}-mdc-tmp
-            echo "### mdc end mode ${mode}" >> ${ENV_FILE}-mdc-tmp
+            echo "### mdc end mode ${mode} (${efile})" >> ${ENV_FILE}-mdc-tmp
         fi
     done
 
     # if there are mode specific files then copy them to MDC_FILES_DIR
-    if [ -d "${MODES_DIR}/${mode}" ]; then
-        for vfd in $(cd ${MODES_DIR}/${mode} && $LS -d */files 2>/dev/null || true); do
+    if [ -d "${path}" ]; then
+        for vfd in $(cd ${path} && $LS -d */files 2>/dev/null || true); do
             dest=${MDC_FILES_DIR}/${vfd%/files}
             mkdir -p ${dest}
-            vecho cp -a ${MODES_DIR}/${mode}/${vfd}/* ${dest}
-            cp -a ${MODES_DIR}/${mode}/${vfd}/* ${dest}
+            vecho cp -a ${path}/${vfd}/* ${dest}
+            cp -a ${path}/${vfd}/* ${dest}
         done
     fi
 done
+
+vecho
+
+# Summarize and set env
+
+echo >&2 "MODES: ${MDC_MODE_NAMES}"
+vecho "ENV_FILE: ${ENV_FILE}"
 
 COMPOSE_FILE="${COMPOSE_FILE#:}"
 vecho "COMPOSE_FILE: ${COMPOSE_FILE}"
@@ -99,6 +109,8 @@ echo "COMPOSE_PROFILES=${COMPOSE_PROFILES}" >> ${ENV_FILE}-mdc-tmp
 MDC_MODE_DIRS="${MDC_MODE_DIRS#,}"
 vecho "MDC_MODE_DIRS: ${MDC_MODE_DIRS}"
 echo "MDC_MODE_DIRS=\"${MDC_MODE_DIRS}\"" >> ${ENV_FILE}-mdc-tmp
+
+vecho
 
 vecho mv ${ENV_FILE}-mdc-tmp ${ENV_FILE}
 mv ${ENV_FILE}-mdc-tmp ${ENV_FILE}

--- a/mdc
+++ b/mdc
@@ -20,7 +20,7 @@ DOCKER_COMPOSE="${DOCKER_COMPOSE:-docker-compose}"
 [ -f "${RESOLVE_DEPS}" ] || die "Missing ${RESOLVE_DEPS}. Perhaps 'npm install'?"
 MODE_SPEC="${1}"; shift
 if [ "${RESOLVE_DEPS}" ]; then
-    MODES="$(${RESOLVE_DEPS} "${MODES_DIR}" ${MODE_SPEC})"
+    MODES="$(${RESOLVE_DEPS} --path "${MODES_DIR}" ${MODE_SPEC})"
 else
     MODES="${MODE_SPEC//,/ }"
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@lonocloud/resolve-deps": "^0.0.2",
+        "@lonocloud/resolve-deps": "^0.1.0",
         "ajv": "^8.12.0",
         "dockerode": "^3.3.4",
         "nbb": "^1.2.179",
@@ -28,9 +28,9 @@
       "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
     },
     "node_modules/@lonocloud/resolve-deps": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@lonocloud/resolve-deps/-/resolve-deps-0.0.2.tgz",
-      "integrity": "sha512-AgZlehvI3j7Wckqr9D/JVw1kgyceHN1mvh9Czl6+X5eNHbREPQzbgRMSJreydOHksdCKh+guD+ppnpbPp7Sgeg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@lonocloud/resolve-deps/-/resolve-deps-0.1.0.tgz",
+      "integrity": "sha512-dj7tlxWt/oXivbhw00w7uFiwCvKxoPy/bvZNwvhsETZbQ1h9sP3nzcH7gR//kXGTCP8kI2FBqDVnDGHUvwuOhw==",
       "dependencies": {
         "nbb": "^0.7.132",
         "neodoc": "^2.0.2"
@@ -1554,9 +1554,9 @@
       "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
     },
     "@lonocloud/resolve-deps": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@lonocloud/resolve-deps/-/resolve-deps-0.0.2.tgz",
-      "integrity": "sha512-AgZlehvI3j7Wckqr9D/JVw1kgyceHN1mvh9Czl6+X5eNHbREPQzbgRMSJreydOHksdCKh+guD+ppnpbPp7Sgeg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@lonocloud/resolve-deps/-/resolve-deps-0.1.0.tgz",
+      "integrity": "sha512-dj7tlxWt/oXivbhw00w7uFiwCvKxoPy/bvZNwvhsETZbQ1h9sP3nzcH7gR//kXGTCP8kI2FBqDVnDGHUvwuOhw==",
       "requires": {
         "nbb": "^0.7.132",
         "neodoc": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@lonocloud/resolve-deps": "^0.0.2",
+    "@lonocloud/resolve-deps": "^0.1.0",
     "ajv": "^8.12.0",
     "dockerode": "^3.3.4",
     "nbb": "^1.2.179",


### PR DESCRIPTION
Updates mdc for the latest resolve-deps work, then adds support for multiple modes directories.

I previously incorrectly added a 'npm install' check into mdc, not seeing that mdc actually supported a path to not use resolve-deps at all.  This seems useful, if we can sustain it (and it doesn't confuse users), so I first restore that functionality and move the check into run-tests.sh.  We can test this continues to work using test4 by explicitly listing modes that would have been resolved.

To support multiple modes directories, we have the resolve-deps-less path return the same "node=/some/path" format that resolve-deps would.  We check all modes directories and ensure that each mode in the mode spec is found and found only once.

As part of this, I added some comments to mdc to delineate creating base compose and files dir, then looping over modes to incorporate their contents, then finally user feedback ("MODES: ...") and setting env for COMPOSE_PROFILES/etc.  The goal was to reduce the processing needed to show "MODES: ...", but it has a small advantage of consolidating the code to show all the env vars we set.

I considered reworking test4 to use multiple modes dirs, but it makes the test4 README fairly verbose.