### PR TITLE
Ensure line ending after copied env

### DIFF
--- a/mdc
+++ b/mdc
@@ -75,6 +75,7 @@ for resolved in ${RESOLVED_MODES}; do
             echo "### mdc begin mode ${mode} (${efile})" >> ${ENV_FILE}-mdc-tmp
             vecho "cat ${efile} >> ${ENV_FILE}-mdc-tmp"
             cat ${efile} >> ${ENV_FILE}-mdc-tmp
+            echo >> ${ENV_FILE}-mdc-tmp
             echo "### mdc end mode ${mode} (${efile})" >> ${ENV_FILE}-mdc-tmp
         fi
     done


### PR DESCRIPTION
If a user creates an env file without a trailing newline, the mdc comments can interfere with the resulting value/environment:

```
$ echo -n "MY_VALUE=123" > modes/somemode/env
$ ./mdc somemode
$ cat .env
MY_VALUE=123### mdc end mode somemode
```