### PR TITLE
Link config merging, stabilize MAC addrs, miscellaneous fixes/docs/cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM node:16-slim as run
 RUN apt-get -y update
 # Runtime deps and utilities
 RUN apt-get -y install libpcap-dev tcpdump iproute2 iputils-ping curl \
-                       iptables bridge-utils ethtool \
+                       iptables bridge-utils ethtool jq \
                        openvswitch-switch openvswitch-testcontroller
 
 COPY --from=build /app/ /app/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@
 Create (layer 2 and layer 3) networking between containers using
 a declarative configuration.
 
+## Why conlink?
+
+There are a number of limitations of docker-compose networking that
+conlink addresses:
+
+* Operates at layer 3 of the network stack (i.e. IP).
+* Has a fixed model of container interface naming: first interface is
+  `eth0`, second is `eth1`, etc.
+* For containers with multiple interfaces, the mapping between docker
+  compose networks and container interface is not controllable
+  (https://github.com/docker/compose/issues/4645#issuecomment-701351876,
+  https://github.com/docker/compose/issues/8561#issuecomment-1872510968)
+* If a container uses the scale property, then IPs cannot be
+  assigned and user assigned MAC addresses will be the same for every
+  instance of that service.
+* Docker bridge networking interferes with switch and bridge protocol
+  traffic (BPDU, STP, LLDP, etc). Conlink supports the "patch" link
+  mode that allows this type of traffic to pass correctly.
+
+Conlink has the following features:
+
+- Declarative network configuration (links, bridges, patches, etc)
+- Event driven (container restarts and scale changes)
+- Low-level control of network interfaces/links: MTU, routes, port
+  forwarding, netem properties, etc
+- Automatic IP and MAC address incrementing for scaled containers
+- Central network container for easy monitoring and debug
+- Composable configuration from multiple sources/locations
+
 ## Prerequisites
 
 General:
@@ -74,12 +103,12 @@ same bridge (broadcast domain).
 Network configuration can either be loaded directly from configuration
 files using the `--network-config` option or it can be loaded from
 `x-network` properties contained in docker-compose files using the
-`--compose-file`. Multiple of each option may be specified and all the
-network configuration will be merged into a final network
-configuration.
+`--compose-file` option. Multiple of each option may be specified and
+all the network configuration will be merged into a final network
+configuration. Both options also support colon separated lists.
 
-The network configuration can have three top level keys: `links`,
-`tunnels`, and `commands`.
+The network configuration can have four top level keys: `links`,
+`bridges`, `tunnels`, and `commands`.
 
 ### Links
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # conlink: Declarative Low-Level Networking for Containers
 
-
 Create (layer 2 and layer 3) networking between containers using
 a declarative configuration.
+
+Conlink also includes scripts that make docker compose a much more
+powerful development and testing environment (refer to
+[Compose scripts](#compose-scripts-mdc-waitsh-and-copysh) for
+details):
+
+* [mdc](#mdc): modular management of multiple compose configurations
+* [wait.sh](#waitsh): wait for network and file conditions before continuing
+* [copy.sh](#copysh): recursively copy files with variable templating
 
 ## Why conlink?
 
@@ -629,6 +637,138 @@ docker-compose -f examples/test10-compose.yaml exec node2 ping 10.1.0.1
 
 ```
 
+## Compose scripts: mdc, wait.sh, and copy.sh
+
+### mdc
+
+The `mdc` command adds flexibility and power to the builtin overlay
+capability of docker compose. Docker compose can specify multiple
+compose files that will be combined into a single configuration.
+Compose files that are specified later will overlay or override
+earlier compose files. For example, if compose files A and B are
+loaded by docker compose, then the `image` property of a service in
+file B will take precedence (or override) the `image` property for the
+same service in file A. Some properties such as `volumes` and
+`environment` will have the sub-properties merged or appended to.
+
+There are several ways that `mdc` adds to the composition capabilities
+of docker compose:
+1. **Mode/module dependency resolution**. The modes or modules that
+   are combined by `mdc` are defined as directories that contain
+   mode/module specific content. A `deps` file in a mode/module
+   directory is used to specify dependencies on other modes/modules.
+   The syntax and resolution algorithm is defined by the
+   [resolve-deps](https://github.com/Viasat/resolve-deps) project.
+2. **Environment variable file combining/overlaying**. Each `.env`
+   file that appears in a mode/module directory will be appended into
+   a single `.env` file at the top-level where the `mdc` command is
+   invoked. Later environment variables will override earlier ones
+   with the same name. Variable interpolation and some shell-style
+   variable expansion can be used to combine/append environment
+   variables. For example if FOO and BAR are defined in an earlier
+   mode/module, then BAZ could be defined like this:
+   `BAZ="${FOO:-${BAR}-SUFF"` which will set BAZ to FOO if FOO is set,
+   otherwise, it will set BAZ to BAR with a "-SUFF" suffix.
+3. **Directory hierarchy combining/overlaying**. If the mode/module
+   directory has subdirectories that themselves contain a "files/"
+   sub-directory, then the mode subdirectories will be recursively
+   copied into the top-level ".files/" directory. For example,
+   consider if the following files exists under the modes "foo" and
+   "bar" (with a dependency of "bar" on "foo"):
+   `foo/svc1/files/etc/conf1`, `foo/svc2/files/etc/conf2`, and
+   `bar/svc1/files/etc/conf1`. When `mdc` is run this will result in
+   the following two files: `.files/svc1/etc/conf1` and
+   `.files/svc2/etc/conf2`. The content of `conf1` will come from the
+   "bar" mode because it is resolved second. The use of the `copy.sh`
+   script (described below) simplifies recursive file copying and also
+   provides variable templating of copied files.
+4. **Set environment variables based on the selected modes/modules**.
+   When `mdc` is run it will set the following special environment
+   variables in the top-level `.env` file:
+   * `COMPOSE_FILE`: A colon separated and dependency ordered list of
+     compose file paths from each resolved mode/module directory.
+   * `COMPOSE_DIR`: The directory where the top-level `.env` is
+     created.
+   * `COMPOSE_PRPOFILES`: A comma separated list of each resolved
+     mode/module with a `MODE_` prefix on the name. These are docker
+     compose profiles that can be used to enable services in one
+     mode/module compose file when a different mode/module is
+     selected/resolved by `mdc`. For example, if a compose file in
+     "bar" has a service that should only be enabled when the "foo"
+     mode/module is also requested/resolved, then the service can be
+     tagged with the `MODE_foo` profile.
+   * `MDC_MODE_DIRS`: A comma separated list of mode/module
+     directories. This can be used by other external tools that have
+     specific mode/module behavior.
+
+Conlink network configuration can be specified in `x-network`
+properties within compose files. This can be a problem with the
+builtin overlay functionality of docker compose because `x-` prefixed
+properties are simply overriden as a whole without any special merging
+behavior. To work around this limitation, conlink has the ability to
+directly merge `x-network` configuration from multiple compose files
+by passing the `COMPOSE_FILE` variable to the conlink `--compose-file`
+parameter (which supports a colon sperated list of compose files).
+
+### wait.sh
+
+The dynamic event driven nature of conlink mean that interfaces may
+appear after the container service code starts running (unlike plain
+docker container networking). For this reason, the `wait.sh` script is
+provided to simplify waiting for interfaces to appear (and other
+network conditions). Here is a compose file snippit that will wait for
+`eth0` to appear and for `eni1` to both appear and have an IP address
+assigned before running the startup command (after the `--`):
+
+```
+services:
+  svc1:
+    volumes:
+      - ./conlink/scripts:/scripts:ro
+    command: /scripts/wait.sh -i eth0 -I eni1 -- /start-cmd.sh arg1 arg2
+```
+
+In addition to waiting for interfaces and address assignment,
+`wait.sh` can also wait for a file to appear (`-f FILE`), a remote TCP
+port to become accessible (`-t HOST:PORT`), or run a command until it
+completes successfully (`-c COMMAND`).
+
+
+### copy.sh
+
+One of the features of the `mdc` command is to collect directory
+hierarchies from mode/module directories into a single `.files/`
+directory at the top-level. The intended use of the merged directory
+hierarchy is to be merged into file-systems of running containers.
+However, simple volume mounts will replace entire directory
+hierarchies (and hide all prior files under the mount point). The
+`copy.sh` script is provided for easily merging/overlaying one
+directory hierarchy onto another one. In addition, the `-T` option
+will also replace special `{{VAR}}` tokens in the files being copied
+with the value of the matching environment variable.
+
+Here is a compose file snippit that shows the use of `copy.sh` to
+recursively copy/overlay the directory tree in `./.files/svc2` onto
+the container root file-system. In addition, due to the use of the
+`-T` option, the script will replace any occurence of the string
+`{{FOO}}` with the value of the `FOO` environment variable within any
+of the files that are copied:
+
+```
+services:
+  svc2:
+    environment:
+      - FOO=123
+    volumes:
+      - ./.files/svc2:/files:ro
+    command: /scripts/copy.sh -T /files / -- /start-cmd.sh arg1 arg2
+```
+
+Note that instances of `copy.sh` and `wait.sh` can be easily chained
+together like this:
+```
+/scripts/copy.sh -T /files / -- /scripts/wait.sh -i eth0 -- cmd args
+```
 
 ## GraphViz network configuration rendering
 

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ validate connectivity using ping:
 ```
 export BRIDGE_MODE="linux"  # "ovs", "patch", "auto"
 docker-compose -f examples/test9-compose.yaml up --build --force-recreate
-docker-compose -f examples/test9-compose.yaml exec node ping 10.0.1.2
+docker-compose -f examples/test9-compose.yaml exec node1 ping 10.0.1.2
 ```
 
 ### test10: port forwarding and routing

--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ The following table describes the link properties:
 | ip        | *          | CIDR           |         | IP CIDR 7                |
 | mac       | 3          | MAC            |         | MAC addr 7               |
 | mtu       | *          | number 4       | 65535   | intf MTU                 |
-| route     | *          | string         |         | ip route add args        |
+| route     | *          | strings 8      |         | ip route add args        |
 | nat       | *          | IP             |         | DNAT/SNAT to IP          |
-| netem     | *          | string         |         | tc qdisc NetEm options   |
+| netem     | *          | strings 8      |         | tc qdisc NetEm options   |
 | mode      | 5          | string         |         | virt intf mode           |
 | vlanid    | vlan       | number         |         | VLAN ID                  |
-| forward   | veth       | string array 6 |         | forward conlink ports 7  |
+| forward   | veth       | strings 6 8    |         | forward conlink ports 7  |
 
 - 1 - veth, dummy, vlan, ipvlan, macvlan, ipvtap, macvtap
 - 2 - defaults to outer compose service
@@ -117,6 +117,7 @@ The following table describes the link properties:
 - 5 - macvlan, macvtap, ipvlan, ipvtap
 - 6 - string syntax: `conlink_port:container_port/proto`
 - 7 - offset by scale/replica index
+- 8 - either a single string or an array of strings
 
 Each link has a 'type' key that defaults to "veth" and each link
 definition must also have either a `service` key or a `container` key.

--- a/examples/test7-compose.yaml
+++ b/examples/test7-compose.yaml
@@ -28,7 +28,12 @@ services:
           ip: 10.0.1.1/16
           mac: 00:0a:0b:0c:0d:01
           mtu: 4111
-          netem: "delay 40ms rate 10mbit"
+          netem: "rate 10mbit delay 40ms"
         - bridge: s2
           ip: 100.0.1.1/16
           dev: eth1
+
+x-network:
+  links:
+    # The delay setting is overridden by the one in the service
+    - {service: node, bridge: s1, netem: "delay 200ms"}

--- a/examples/test9-compose.yaml
+++ b/examples/test9-compose.yaml
@@ -19,14 +19,19 @@ services:
       - BRIDGE_MODE
     command: /app/build/conlink.js --default-bridge-mode linux --compose-file /test/test9-compose.yaml
 
-  node:
+  node1:
     image: alpine
     network_mode: none
-    scale: 2
+    command: sleep Infinity
+
+  node2:
+    image: alpine
+    network_mode: none
     command: sleep Infinity
 
 x-network:
   links:
-    - {bridge: s1, service: node, ip: 10.0.1.1/24}
+    - {bridge: s1, service: node1, ip: 10.0.1.1/24}
+    - {bridge: s1, service: node2, ip: 10.0.1.2/24}
   bridges:
     - {bridge: s1, mode: "${BRIDGE_MODE:-auto}"}

--- a/link-add.sh
+++ b/link-add.sh
@@ -42,7 +42,7 @@ usage () {
   echo >&2 "  --remote REMOTE          - Remote address for geneve/vxlan types"
   echo >&2 "  --vni VNI                - Virtual Network Identifier for geneve/vxlan types"
   echo >&2 ""
-  echo >&2 "  --netem NETEM            - tc qdisc netem OPTIONS (man 8 netem)"
+  echo >&2 "  --netem NETEM            - tc qdisc netem OPTIONS (man 8 netem) (can repeat)"
   echo >&2 "  --nat TARGET             - Stateless NAT traffic to/from TARGET"
   echo >&2 "                             (in primary/PID0 netns)"
   echo >&2 ""
@@ -104,7 +104,7 @@ while [ "${*}" ]; do
   --remote)         REMOTE="${OPTARG}"; shift ;;
   --vni)            VNI="${OPTARG}"; shift ;;
 
-  --netem)          NETEM="${OPTARG}"; shift ;;
+  --netem)          NETEM="${NETEM} ${OPTARG}"; shift ;;
   --nat)            NAT="${OPTARG}"; shift ;;
   -h|--help)        usage ;;
   *)                positional="${positional} $1" ;;

--- a/net2dot.cljs
+++ b/net2dot.cljs
@@ -29,7 +29,7 @@
       (S/replace #"[*]" "_STAR_")
       (S/replace #"[$]" "_DOLLAR_")
       (S/replace #"[{]" "_LCURLY_")
-      (S/replace #"[}]" "_LCURLY_")
+      (S/replace #"[}]" "_RCURLY_")
       (S/replace #"[ ]" "_SPACE_")))
 
 (defn node-props [label props]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",

--- a/schema.yaml
+++ b/schema.yaml
@@ -42,7 +42,6 @@ properties:
         mac:       { "$ref": "#/$defs/mac" }
         mtu:       {type: number}
         nat:       { "$ref": "#/$defs/ip" }
-        netem:     {type: string}
         mode:      {type: string}
         vlanid:    {type: number}
         route:
@@ -51,6 +50,9 @@ properties:
         forward:
           oneOf: [{ "$ref": "#/$defs/fwd" },
                   {type: array, items: { "$ref": "#/$defs/fwd" }}]
+        netem:
+          oneOf: [{type: string},
+                  {type: array, items: {type: string}}]
 
   bridges:
     type: array
@@ -69,7 +71,9 @@ properties:
         bridge:    {type: string}
         remote:    { "$ref": "#/$defs/ip" }
         vni:       {type: number}
-        netem:     {type: string}
+        netem:
+          oneOf: [{type: string},
+                  {type: array, items: {type: string}}]
 
   commands:
     type: array

--- a/src/conlink/core.cljs
+++ b/src/conlink/core.cljs
@@ -171,11 +171,11 @@ General Options:
         _ (when (and (= :patch mode) (not kmod-mirred?))
             (warn (str "bridge " bridge " mode is 'patch', "
                        "but no 'act_mirred' kernel module loaded, "
-                       " assuming it will load when needed.")))
+                       "assuming it will load when needed.")))
         _ (when (and (= :auto mode) (not kmod-ovs?))
             (warn (str "bridge " bridge " mode is 'auto', "
-                       " but no 'openvswitch' kernel module loaded, "
-                       " so falling back to 'linux'")))
+                       "but no 'openvswitch' kernel module loaded, "
+                       "so falling back to 'linux'")))
         mode (if (= :auto mode)
               (if kmod-ovs? :ovs :linux)
               mode)]
@@ -218,8 +218,7 @@ General Options:
          (if (not (empty? params)) (str " " params) ""))))
 
 (defn check-schema [data schema verbose]
-  (let [{:keys [info warn]} @ctx
-        ajv (Ajv. #js {:allErrors true})
+  (let [ajv (Ajv. #js {:allErrors true})
         validator (.compile ajv (->js schema))
         valid (validator (->js data))]
     (if valid

--- a/src/conlink/core.cljs
+++ b/src/conlink/core.cljs
@@ -595,8 +595,9 @@ General Options:
   running in a container)"
   []
   (P/let [[cgroup mountinfo]
-          , (P/all [(read-file "/proc/self/cgroup" "utf8")
-                    (read-file "/proc/self/mountinfo" "utf8")])
+          , (P/catch (P/all [(read-file "/proc/self/cgroup" "utf8")
+                             (read-file "/proc/self/mountinfo" "utf8")])
+              #(vector "" ""))
           ;; docker
           d-cgroups (map second (re-seq #"/docker/([^/\n]*)" cgroup))
           ;; podman (root)

--- a/src/conlink/core.cljs
+++ b/src/conlink/core.cljs
@@ -124,6 +124,7 @@ General Options:
         bridge (get bridges bridge)
         route (if (string? route) [route] route)
         forward (if (string? forward) [forward] forward)
+        netem (if (string? netem) [netem] netem)
         link (merge
                link
                {:type type
@@ -142,7 +143,9 @@ General Options:
                           [(js/parseInt port_a) (js/parseInt port_b) proto])
                        forward)})
                (when (and forward docker-eth0-address)
-                 {:route (conj route (str docker-eth0-address "/32"))}))]
+                 {:route (conj route (str docker-eth0-address "/32"))})
+               (when netem
+                 {:netem netem}))]
     (when forward
       (let [link-id (str (or (:service link) (:container link)) ":" dev)
             pre (str "link '" link-id "' has forward setting")]

--- a/src/conlink/util.cljs
+++ b/src/conlink/util.cljs
@@ -44,7 +44,7 @@
   (js/process.exit code))
 
 (defn deep-merge [a b]
-  (merge-with #(cond (map? %1) (recur %1 %2)
+  (merge-with #(cond (map? %1) (deep-merge %1 %2)
                      (vector? %1) (vec (concat %1 %2))
                      (sequential? %1) (concat %1 %2)
                      :else %2)

--- a/test/test9.yaml
+++ b/test/test9.yaml
@@ -32,7 +32,8 @@ tests:
         run: |
           echo "Restart the second node"
           ${DC} up -d -t1 --scale node2=0 && ${DC} up -d --scale node2=1
-      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node1, run: ping -c2 -w2 10.0.1.2,
+         repeat: { retries: 3, interval: '2s' }}
       - {exec: node2, run: ping -c1 -w2 10.0.1.1}
 
       - exec: :host
@@ -57,7 +58,7 @@ tests:
         repeat: { retries: 10, interval: '2s' }
 
       # Check for round-trip ping connectivity
-      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node1, run: ping -c2 -w2 10.0.1.2}
       - {exec: node2, run: ping -c1 -w2 10.0.1.1}
 
       # Restart second node and check again
@@ -65,7 +66,8 @@ tests:
         run: |
           echo "Restart the second node"
           ${DC} up -d -t1 --scale node2=0 && ${DC} up -d --scale node2=1
-      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node1, run: ping -c1 -w2 10.0.1.2,
+         repeat: { retries: 3, interval: '2s' }}
       - {exec: node2, run: ping -c1 -w2 10.0.1.1}
 
       - exec: :host
@@ -100,7 +102,8 @@ tests:
         run: |
           echo "Restart the second node"
           ${DC} up -d -t1 --scale node2=0 && ${DC} up -d --scale node2=1
-      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node1, run: ping -c2 -w2 10.0.1.2,
+         repeat: { retries: 3, interval: '2s' }}
       - {exec: node2, run: ping -c1 -w2 10.0.1.1}
 
       - exec: :host

--- a/test/test9.yaml
+++ b/test/test9.yaml
@@ -19,13 +19,21 @@ tests:
           echo "waiting for conlink startup"
           ${DC} logs network | grep "All links connected"
         repeat: { retries: 30, interval: '1s' }
-      - exec: node
+      - exec: node1
         run: ip addr | grep "10\.0\.1\.1"
         repeat: { retries: 10, interval: '2s' }
 
       # Check for round-trip ping connectivity
-      - {exec: node, index: 1, run: ping -c1 -w2 10.0.1.2}
-      - {exec: node, index: 2, run: ping -c1 -w2 10.0.1.1}
+      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node2, run: ping -c1 -w2 10.0.1.1}
+
+      # Restart second node and check again
+      - exec: :host
+        run: |
+          echo "Restart the second node"
+          ${DC} up -d -t1 --scale node2=0 && ${DC} up -d --scale node2=1
+      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node2, run: ping -c1 -w2 10.0.1.1}
 
       - exec: :host
         run: ${DC} down --remove-orphans --volumes -t1
@@ -44,13 +52,21 @@ tests:
           echo "waiting for conlink startup"
           ${DC} logs network | grep "All links connected"
         repeat: { retries: 30, interval: '1s' }
-      - exec: node
+      - exec: node1
         run: ip addr | grep "10\.0\.1\.1"
         repeat: { retries: 10, interval: '2s' }
 
       # Check for round-trip ping connectivity
-      - {exec: node, index: 1, run: ping -c1 -w2 10.0.1.2}
-      - {exec: node, index: 2, run: ping -c1 -w2 10.0.1.1}
+      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node2, run: ping -c1 -w2 10.0.1.1}
+
+      # Restart second node and check again
+      - exec: :host
+        run: |
+          echo "Restart the second node"
+          ${DC} up -d -t1 --scale node2=0 && ${DC} up -d --scale node2=1
+      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node2, run: ping -c1 -w2 10.0.1.1}
 
       - exec: :host
         run: ${DC} down --remove-orphans --volumes -t1
@@ -69,15 +85,23 @@ tests:
           echo "waiting for conlink startup"
           ${DC} logs network | grep "All links connected"
         repeat: { retries: 30, interval: '1s' }
-      - exec: node
+      - exec: node1
         run: ip addr | grep "10\.0\.1\.1"
         repeat: { retries: 10, interval: '2s' }
 
       # Ensure ingest filter rules exist
-      - {exec: network, run: 'tc filter show dev node_1-eth0 parent ffff: | grep "action order 1: mirred"'}
+      - {exec: network, run: 'tc filter show dev node1_1-eth0 parent ffff: | grep "action order 1: mirred"'}
       # Check for round-trip ping connectivity
-      - {exec: node, index: 1, run: ping -c1 -w2 10.0.1.2}
-      - {exec: node, index: 2, run: ping -c1 -w2 10.0.1.1}
+      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node2, run: ping -c1 -w2 10.0.1.1}
+
+      # Restart second node and check again
+      - exec: :host
+        run: |
+          echo "Restart the second node"
+          ${DC} up -d -t1 --scale node2=0 && ${DC} up -d --scale node2=1
+      - {exec: node1, run: ping -c1 -w2 10.0.1.2}
+      - {exec: node2, run: ping -c1 -w2 10.0.1.1}
 
       - exec: :host
         run: ${DC} down --remove-orphans --volumes -t1


### PR DESCRIPTION
Main changes:
* Merge of link properties from multiple locations. Link configs with the same container/service and internal device name are merged. Array/sequence properties are appended, other properties are overridden.
* When the config doesn't specify a MAC address, generate a random MAC address that starts with 'c2' and use this when the link is recreated. This avoid long ARP timeouts for other containers in some broadcast domain that are aware of this address.
* Documentation: Add rationale/features of conlink. Add documentation for mdc, wait.sh, and copy.sh.
* Support string array (in addition to single string) property for netem.
* Fix an occasional delete race by saving container state. We previously relied on the ability to inspect container state after all events including "die" (delete) events. However, sometimes after the "die" event, the container is fully gone and we can't get the container state so we fail to fully cleanup from the delete. This results in stale state that prevents us from recreating the links in a container when it restarts. So we save the container state on start/creates and then use this saved state for "die" events.
* test9: test link recreation on container restart. Test this for all three bridge modes that are tested (auto, linux, patch).
* Bump to 2.4.0.
  
Other changes:
* Non-fatal fail reading /proc (--show-config more usable).
* Move default mtu/bridge-mode from state to config
* Misc cleanup: extraneous spaces, unused functions.
* conlink/util: fix deep-merge recur hang.
* link-mirred.sh: make tc ingest/filter more idempotent.
* Dockerfile: Add jq to runtime available tools
* net2dot: fix '}' replacement label.