### PR TITLE
Add 'ethtool' link setting. Disable veth tx offload by default. Bump to 2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The following table describes the link properties:
 | mode      | 5          | string         |         | virt intf mode           |
 | vlanid    | vlan       | number         |         | VLAN ID                  |
 | forward   | veth       | strings 6 8    |         | forward conlink ports 7  |
+| ethtool   | veth       | strings 8      |         | ethtool settings         |
 
 - 1 - veth, dummy, vlan, ipvlan, macvlan, ipvtap, macvtap
 - 2 - defaults to outer compose service
@@ -187,6 +188,12 @@ forwarded then the second replica will have port 81 forwarded.
 For publicly publishing a port, the conlink container needs to be on
 a docker network and the `conlink_port` should match the target port
 of a docker published port (for the conlink container).
+
+For the `ethtool` property, refer to the `ethtool` man page. The
+syntax for each ethtool setting is basically the ethtool command line
+arguments without the "devname. So the equivalent of the ethtool
+command `ethtool --offload eth0 rx off` would be link configuration
+`{dev: eth0, ethtool: ["--offload rx off"], ...}`.
 
 ### Bridges
 

--- a/examples/test7-compose.yaml
+++ b/examples/test7-compose.yaml
@@ -29,6 +29,7 @@ services:
           mac: 00:0a:0b:0c:0d:01
           mtu: 4111
           netem: "rate 10mbit delay 40ms"
+          ethtool: "--offload rx off"
         - bridge: s2
           ip: 100.0.1.1/16
           dev: eth1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",

--- a/schema.yaml
+++ b/schema.yaml
@@ -53,6 +53,9 @@ properties:
         netem:
           oneOf: [{type: string},
                   {type: array, items: {type: string}}]
+        ethtool:
+          oneOf: [{type: string},
+                  {type: array, items: {type: string}}]
 
   bridges:
     type: array


### PR DESCRIPTION
- Add 'ethtool' property to links (basically ethtool commands without the devname)
- Disable tx offload by default for veth interfaces. This is the safe default. Could have perf impact so add --keep-veth-offload option to restore the old behavior.
- Bump to 2.5.0