### PR TITLE
Fix cid based oifs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as build
+FROM node:16 AS build
 
 RUN apt-get -y update && \
     apt-get -y install libpcap-dev default-jdk-headless
@@ -19,7 +19,7 @@ RUN cd /app && \
     shadow-cljs compile conlink && \
     chmod +x build/*.js
 
-FROM node:16-slim as run
+FROM node:16-slim AS run
 
 RUN apt-get -y update
 # Runtime deps and utilities
@@ -31,5 +31,5 @@ COPY --from=build /app/ /app/
 ADD link-add.sh link-del.sh link-mirred.sh link-forward.sh /app/
 ADD schema.yaml /app/build/
 
-ENV PATH /app:$PATH
+ENV PATH=/app:$PATH
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/conlink/core.cljs
+++ b/src/conlink/core.cljs
@@ -663,7 +663,8 @@ General Options:
     [container (inspect-container container-obj)
      clabels (get-compose-labels container)
      svc-num (:container-number clabels)]
-    {:name (->> container :Name (re-seq #"(.*/)?(.*)") first last)
+    {:id (:Id container)
+     :name (->> container :Name (re-seq #"(.*/)?(.*)") first last)
      :index (if svc-num (js/parseInt svc-num) 1)
      :service (:service clabels)
      :pid (-> container :State :Pid)


### PR DESCRIPTION
This PR re-introduces the container [id](https://github.com/LonoCloud/conlink/commit/501e3423e4e1c2d20afdbd5fd8740697676ea983#diff-7e6e972de922d5fe7765ba95ae8824e3bfa96f58ec7fa4de0d166124c75c11c5L772) key, which was removed during a fix/refactoring before the 2.4.0 release. This id is used when [naming outer link devices](https://github.com/LonoCloud/conlink/blob/master/src/conlink/core.cljs#L279-L282) if the service+device name is too long, so we hit a missing `.substring` error for null when service names are long.  conlink examples use terse names, so this case is never hit in GHA.

Also clean up Dockerfile to comply with the buildx checks, and bump to 2.5.1.

Let's discuss (in comments or offline) how we want to approach testing specific cases that may be more of a distraction than benefit in human-targeted examples/docs.  For instance, I could trigger this in GHA by renaming the r0 service in example 1 to router0, but that feels awkward and perhaps less standard/clear.  I would also like to test the link merging functionality.  Do we want an example that is intended to be "random knowedge for advanced users" where we can put a long list of random cases to test, or do we want to start a new set of tests specifically for integration testing?