### PR TITLE
net2dot, --show config, dockerode fixes, drop version from base compose file

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  compose-tests:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,3 +22,11 @@ jobs:
       - name: "dctest test/test*.yaml"
         timeout-minutes: 5
         run: time node_modules/.bin/dctest --verbose-commands conlink-test $(ls -v test/test*.yaml)
+
+      - name: Check --show-config and net2dot
+        run: |
+          cfg=$(./conlink --show-config --compose-file examples/test1-compose.yaml)
+          summary=$(echo "${cfg}" | jq -r '.|"\(.bridges|keys|sort|join(".")) \(.services|keys|sort|join("."))"')
+          [ "${summary}" = "s1.s2.s3 h1.h2.h3.r0" ]
+          dot=$(echo "${cfg}" | ./net2dot)
+          [ $(echo "${dot}" | grep "r0.*eth" | wc -l) -ge 10 ]

--- a/mdc
+++ b/mdc
@@ -30,7 +30,7 @@ RESOLVED_MODES="$(${RESOLVE_DEPS} --path "${MODES_DIR}" --format=paths ${MODE_SP
 
 COMPOSE_FILE=./.compose-empty.yaml
 cat /dev/null > ${ENV_FILE}-mdc-tmp
-echo -e "version: '2.4'\nservices: {}" > ./.compose-empty.yaml
+echo -e "services: {}" > ./.compose-empty.yaml
 
 vecho "Removing ${MDC_FILES_DIR}"
 case "$(basename ${MDC_FILES_DIR})" in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/conlink/core.cljs
+++ b/src/conlink/core.cljs
@@ -979,7 +979,9 @@ General Options:
                (P/let
                  [event-filter {"event" ["start" "die"]}
                   ;; Listen for docker and/or podman events
-                  _ (docker-listen client event-filter handle-event)
+                  ;; NOTE: sometimes (podman on macos) this blocks
+                  ;; until the first event. Wrap it to skip await.
+                  _ [(docker-listen client event-filter handle-event)]
                   containers ^obj (list-containers client)]
                  ;; Generate fake events for existing containers
                  (P/all (for [container containers

--- a/src/conlink/core.cljs
+++ b/src/conlink/core.cljs
@@ -906,7 +906,7 @@ General Options:
      docker-eth0-addresses (when docker-eth0? (intf-ipv4-addresses "eth0"))
      _ (swap! ctx merge {:kmod-ovs? kmod-ovs?
                          :kmod-mirred? kmod-mirred?
-                         :docker-eth0? docker-eth0?
+                         :docker-eth0? (or docker-eth0? show-config)
                          :docker-eth0-address (first docker-eth0-addresses)})
      network-config (P/-> (load-configs compose-file network-file)
                           (interpolate-walk env)


### PR DESCRIPTION
- Fix `.getEvents` call that blocks in some cases (podman machine maybe?)
- fix `--show-config` to not fail if `eth0` doesn't exit
- Fix net2dot to use current `--show-config` syntax
- Remove `version` field from empty compose file (version is deprecated now)