### PR TITLE
Use the last container id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "yaml": "^2.2.1"
       },
       "devDependencies": {
-        "@lonocloud/dctest": "0.1.1",
+        "@lonocloud/dctest": "^0.3.1",
         "docsify-cli": "^4.4.4",
         "shadow-cljs": "^2.25.7",
         "source-map-support": "^0.5.21"
@@ -54,17 +54,19 @@
       }
     },
     "node_modules/@lonocloud/dctest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@lonocloud/dctest/-/dctest-0.1.1.tgz",
-      "integrity": "sha512-WIPeMoPGc6UO8zoA/c2oycWFvEUOCCpA8xHPPeeqCMFQDpo5yTWJr6oEBFGXW+KcNJRJqQ1zZYKgp5BXc8r+ZQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@lonocloud/dctest/-/dctest-0.3.1.tgz",
+      "integrity": "sha512-iLs1+qY5JMcgTbfB0J7COKnNAmVdPdHCCU2S5Pu7tFmPmZ168oGh8YAGSTeU2vytzHTc7pMH9A/u9tmnW+UBMg==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/cljs-utils": "0.1.3",
+        "@lonocloud/resolve-deps": "^0.1.0",
         "ajv": "^8.12.0",
         "dockerode": "^3.3.1",
         "ebnf": "1.9.1",
         "js-yaml": "^4.1.0",
-        "nbb": "^1.2.179",
+        "nbb": "^1.2.190",
         "neodoc": "^2.0.2",
         "shadow-cljs": "^2.28.6",
         "source-map-support": "^0.5.21"
@@ -2312,9 +2314,10 @@
       "optional": true
     },
     "node_modules/nbb": {
-      "version": "1.2.188",
-      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.2.188.tgz",
-      "integrity": "sha512-g8UQQEKP8ubw8UaJxJtvUekJXozHlW3b6FoUfDiqG/imaUk6xr1X5L6fl2cNHI/xgM+B/Jxy4pjaxR4KxpbLCQ==",
+      "version": "1.3.195",
+      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.3.195.tgz",
+      "integrity": "sha512-AMKqA+lZ/9rKpaAKarAIo+Nm/N9hRnUEQVsubgUpb0OIg0KhUFVCFUorIihr3y8vCkUSrwiR/mCuuea11XKy+Q==",
+      "license": "EPL-1.0",
       "dependencies": {
         "import-meta-resolve": "^2.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "yaml": "^2.2.1"
   },
   "devDependencies": {
-    "@lonocloud/dctest": "0.1.1",
+    "@lonocloud/dctest": "^0.3.1",
     "docsify-cli": "^4.4.4",
     "shadow-cljs": "^2.25.7",
     "source-map-support": "^0.5.21"

--- a/src/conlink/core.cljs
+++ b/src/conlink/core.cljs
@@ -615,17 +615,9 @@ General Options:
   if no container ID can be determined (e.g. we are probably not
   running in a container)"
   []
-  (P/let [[cgroup mountinfo]
-          , (P/catch (P/all [(read-file "/proc/self/cgroup" "utf8")
-                             (read-file "/proc/self/mountinfo" "utf8")])
-              #(vector "" ""))
-          ;; docker
-          d-cgroups (map second (re-seq #"/docker/([^/\n]*)" cgroup))
-          ;; podman (root)
-          p-cgroups (map second (re-seq #"libpod-([^/.\n]*)" cgroup))
-          ;; general fallback
-          o-mounts (map second (re-seq #".*containers/([^/]{64})/.*/etc/hosts" mountinfo))]
-    (first (concat d-cgroups p-cgroups o-mounts))))
+  (P/->> (P/catch (read-file "/proc/self/mountinfo" "utf8") (constantly ""))
+         (re-find #".*containers/([^/]{64})/.*/etc/hosts")
+         second))
 
 (defn list-containers
   "Return a sequence of container objects optionally limited to those

--- a/src/conlink/core.cljs
+++ b/src/conlink/core.cljs
@@ -624,7 +624,7 @@ General Options:
           ;; podman (root)
           p-cgroups (map second (re-seq #"libpod-([^/.\n]*)" cgroup))
           ;; general fallback
-          o-mounts (map second (re-seq #"containers/([^/]{64})/.*/etc/hosts" mountinfo))]
+          o-mounts (map second (re-seq #".*containers/([^/]{64})/.*/etc/hosts" mountinfo))]
     (first (concat d-cgroups p-cgroups o-mounts))))
 
 (defn list-containers


### PR DESCRIPTION
Adjust the regex to use the last container id in a scenario where there are nested docker containers (e.g. docker in docker).

For example, in this simplified example, `id1` is the parent container and `id2` is the child container.  We want the child container, `id2`:

 '../containers/<id1>/.../containers/<id2>/...'