### PR TITLE
rust/copy: exec cmd rather than just calling it.

### DIFF
--- a/rust/src/copy.rs
+++ b/rust/src/copy.rs
@@ -9,6 +9,7 @@ use std::{
     io::{Read, Write},
     path::PathBuf,
     process::Command,
+    os::unix::process::CommandExt,
 };
 use clap::Parser;
 
@@ -93,12 +94,15 @@ fn main() -> Result<()> {
 
     // Execute command if provided
     if !opt.command.is_empty() {
+        if !which::which(&opt.command[0]).is_ok() {
+            eprintln!("Error: '{}' not found", opt.command[0]);
+            std::process::exit(1);
+        }
+        // Exec the command, replacing the current process
         println!("Running: {:?}", opt.command);
-        let status = Command::new(&opt.command[0])
+        Command::new(&opt.command[0])
             .args(&opt.command[1..])
-            .status()
-            .context("Failed to execute command")?;
-        std::process::exit(status.code().unwrap_or(1));
+            .exec();
     }
 
     Ok(())

--- a/rust/src/wait.rs
+++ b/rust/src/wait.rs
@@ -39,9 +39,10 @@ fn main() {
                         std::process::exit(1);
                     }
                     // Exec the command, replacing the current process
+                    println!("Running: {:?}", command);
                     Command::new(&command[0])
                         .args(&command[1..])
-                        .exec(); // This replaces the current process and doesn't return
+                        .exec();
                 }
                 return; // If no command is provided after '--', exit
             }


### PR DESCRIPTION
The wait command was already doing this but copy was not. For many services this is not an issue. However, systemd init processes expect to be the first process (pid 1), and fail with this error if they are not:
    Couldn't find an alternative telinit implementation to spawn.

Also, add running command print to wait to be consistent with copy (and with the original wait.sh).