### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,3 +35,74 @@ jobs:
           [ "${summary}" = "s1.s2.s3 h1.h2.h3.r0" ]
           dot=$(echo "${cfg}" | ./net2dot)
           [ $(echo "${dot}" | grep "r0.*eth" | wc -l) -ge 10 ]
+
+  # Decide if a release is necessary, do any release linting/checks
+  check-release:
+    needs: [ tests ]
+    name: Check Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')
+    outputs:
+      RELEASE_VERSION: ${{ steps.get-version.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with: { submodules: 'recursive', fetch-depth: 0 }
+
+      - id: get-version
+        name: Get release version
+        run: |
+          echo "RELEASE_VERSION=$(jq -r .version package.json)" | tee "$GITHUB_ENV" | tee "$GITHUB_OUTPUT"
+
+      - name: Check git tag matches release version
+        run: |
+          [ "refs/tags/v${RELEASE_VERSION}" == "${{ github.ref }}" ]
+
+  release-npm:
+    needs: [ check-release ]
+    name: Release NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with: { submodules: 'recursive', fetch-depth: 0 }
+
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: ''
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release-docker-hub:
+    needs: [ check-release ]
+    name: Release Docker Hub
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.check-release.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with: { submodules: 'recursive', fetch-depth: 0 }
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: lonocloud/conlink:${{ env.RELEASE_VERSION }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: lonocloud/conlink:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###
 ### conlink build (ClojureScript)
 ###
-FROM node:16 AS cljs-build
+FROM node:20 AS cljs-build
 
 RUN apt-get -y update && \
     apt-get -y install libpcap-dev default-jdk-headless
@@ -51,12 +51,12 @@ RUN cd /app/target/x86_64-unknown-linux-musl/release/ && cp -v wait copy echo /a
 ###
 ### conlink runtime stage
 ###
-FROM node:16-slim AS run
+FROM node:20-slim AS run
 
 RUN apt-get -y update
 # Runtime deps and utilities
 RUN apt-get -y install libpcap-dev tcpdump iproute2 iputils-ping curl \
-                       iptables bridge-utils ethtool jq netcat socat \
+                       iptables bridge-utils ethtool jq netcat-openbsd socat \
                        openvswitch-switch openvswitch-testcontroller
 
 RUN mkdir -p /app /utils

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/LonoCloud/conlink",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
These changes will automatically do NPM and Docker Hub releases, when we push a git tag of the form 'vX.Y.Z'. Before we release, we run all tests and verify the git tag matches our package.json.

Additionally, update the node version used in the Docker image.  I had to find another candidate for 'netcat' and chose 'netcat-openbsd' (vs. 'netcat-traditional), but I'm open to other opinions/expertise.