### PR TITLE
fix chown syntax

### DIFF
--- a/scripts/copy.sh
+++ b/scripts/copy.sh
@@ -25,7 +25,7 @@ dst_dir="${1}"; shift || die 2 "Usage: ${0} [-T|--template] SRC_DIR DST_DIR"
   echo cp -a "${src}" "${dst}"
   cp -a "${src}" "${dst}" || die 1 "Failed to copy file"
   # TODO: make this configurable
-  chown root.root "${dst}" || die 1 "Unable to set ownership"
+  chown root:root "${dst}" || die 1 "Unable to set ownership"
   chmod +w "${dst}" || die 1 "Unable to make writable"
 
   [ -z "${TEMPLATE}" ] && continue


### PR DESCRIPTION
Some `chown` binaries seem to support the `.` notation, but a few don't.  I haven't looked into why that is.  Since `:` is the arguably ubiquitous, conventional, and universal (?) syntax, I'm changing it to head in that direction.  That said, usage of `copy.sh` should probably be phased out, anyway, and the from-rust-built binary `copy` should be used instead.