### PR TITLE
Update doc reqs and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Conlink has the following features:
 
 General:
 * docker
-* docker-compose version 1.25.4 or later.
+* docker-compose v2
 
 Other:
 * For Open vSwtich (OVS) bridging, the `openvswitch` kernel module

--- a/README.md
+++ b/README.md
@@ -38,22 +38,22 @@ services:
         - {bridge: s1, ip: 10.0.1.1/24}
 ```
 
-Check out the [runnable examples](https://github.com/LonoCloud/conlink/tree/master/examples)
-for more ideas on what is possible. [This guide](https://lonocloud.github.io/conlink/#/guides/examples)
+Check out the [runnable examples](https://github.com/Viasat/conlink/tree/master/examples)
+for more ideas on what is possible. [This guide](https://viasat.github.io/conlink/#/guides/examples)
 walks through how to run each example.
 
-The [reference documentation](https://lonocloud.github.io/conlink/#/reference/network-configuration-syntax)
-contains the full list of configuration options. Be sure to also read [usage notes](https://lonocloud.github.io/conlink/#/usage-notes),
+The [reference documentation](https://viasat.github.io/conlink/#/reference/network-configuration-syntax)
+contains the full list of configuration options. Be sure to also read [usage notes](https://viasat.github.io/conlink/#/usage-notes),
 which highlight some unique aspects of using conlink-provided networking.
 
 Conlink also includes tools that make docker compose a much more
 powerful development and testing environment (refer to
-[Compose Tools](https://lonocloud.github.io/conlink/#/guides/compose-tools) for
+[Compose Tools](https://viasat.github.io/conlink/#/guides/compose-tools) for
 details):
 
-* [mdc](https://lonocloud.github.io/conlink/#/guides/compose-tools?id=mdc): modular management of multiple compose configurations
-* [wait](https://lonocloud.github.io/conlink/#/guides/compose-tools?id=wait): wait for network and file conditions before continuing
-* [copy](https://lonocloud.github.io/conlink/#/guides/compose-tools?id=copy): recursively copy files with variable templating
+* [mdc](https://viasat.github.io/conlink/#/guides/compose-tools?id=mdc): modular management of multiple compose configurations
+* [wait](https://viasat.github.io/conlink/#/guides/compose-tools?id=wait): wait for network and file conditions before continuing
+* [copy](https://viasat.github.io/conlink/#/guides/compose-tools?id=copy): recursively copy files with variable templating
 
 ## Why conlink?
 

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-The [examples](https://github.com/LonoCloud/conlink/tree/master/examples)
+The [examples](https://github.com/Viasat/conlink/tree/master/examples)
 directory contains the necessary files to follow along below.
 
 The examples also require a conlink docker image. Build the image for both

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,8 +14,8 @@
   <script>
     window.$docsify = {
       name: 'conlink',
-      repo: 'LonoCloud/conlink',
-      homepage: 'https://raw.githubusercontent.com/LonoCloud/conlink/master/README.md',
+      repo: 'Viasat/conlink',
+      homepage: 'https://raw.githubusercontent.com/Viasat/conlink/master/README.md',
       // Uncomment to follow a symlink to root README.md and test rendering locally
       //homepage: '_render-local-README.md',
 

--- a/examples/test6-cfn.yaml
+++ b/examples/test6-cfn.yaml
@@ -89,7 +89,7 @@ Resources:
 
         ## Download conlink image and repo
         docker pull lonocloud/conlink
-        git clone https://github.com/LonoCloud/conlink /root/conlink
+        git clone https://github.com/Viasat/conlink /root/conlink
         cd /root/conlink
 
         #cfn-signal -e 0 --stack ${AWS::StackName} --region ${AWS::Region} --resource WaitHandle

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "conlink",
   "version": "2.5.7",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
-  "repository": "https://github.com/LonoCloud/conlink",
+  "repository": "https://github.com/Viasat/conlink",
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@lonocloud/resolve-deps": "^0.1.0",

--- a/src/conlink/addrs.cljc
+++ b/src/conlink/addrs.cljc
@@ -6,7 +6,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Network Address functions
-;; - based on github.com/LonoCloud/clj-protocol
+;; - based on github.com/Viasat/clj-protocol
 
 (defn num->string [n base]
   #?(:cljs  (.toString n base)


### PR DESCRIPTION
- Update requirements to include Docker Compose v2 (required by mdc)
- Fix GitHub Pages link post-LonoCloud organization migration