### PR TITLE
Update gha workflow to use OIDC when publishing to npm

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -62,21 +62,27 @@ jobs:
     needs: [ check-release ]
     name: Release NPM
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with: { submodules: 'recursive', fetch-depth: 0 }
 
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
-          scope: ''
+
+      - name: Upgrade npm to support OIDC
+        run: |
+          npm install -g npm@11.12.0
+          node --version
+          npm --version
 
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release-docker-hub:
     needs: [ check-release ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.6.2",
+  "version": "2.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.6.2",
+      "version": "2.6.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.6.2",
+  "version": "2.6.4",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/Viasat/conlink",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Switching npm publishing to use OIDC will resolve an issue where the existing access token is no longer valid while also preventing a need to manage token rotation.