### PR TITLE
Build/push multiplatform image (add arm64)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -89,20 +89,25 @@ jobs:
         uses: actions/checkout@v4
         with: { submodules: 'recursive', fetch-depth: 0 }
 
+      # For multi-platform build
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push (multi-arch)
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: lonocloud/conlink:${{ env.RELEASE_VERSION }}
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            lonocloud/conlink:${{ env.RELEASE_VERSION }}
+            lonocloud/conlink:latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          tags: lonocloud/conlink:latest

--- a/examples/test12-k3s/k3s-init.sh
+++ b/examples/test12-k3s/k3s-init.sh
@@ -10,10 +10,10 @@ ln -sfn /var/lib/rancher/k3s/agent/etc/cni/net.d      /etc/cni/net.d
 
 mkdir -p /var/lib/rancher/k3s/agent/etc/containerd/
 cat > /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl <<EOF
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
   SystemdCgroup = false
 
-[plugins."io.containerd.grpc.v1.cri".cni]
+[plugins."io.containerd.cri.v1.runtime".cni]
   bin_dir  = "/var/lib/rancher/k3s/data/cni"
   conf_dir = "/var/lib/rancher/k3s/agent/etc/cni/net.d"
 EOF

--- a/examples/test12-k3s/k3s-init.sh
+++ b/examples/test12-k3s/k3s-init.sh
@@ -28,6 +28,12 @@ K3S_ARGS="${K3S_ARGS} --kubelet-arg=cgroup-root=/"
 K3S_ARGS="${K3S_ARGS} --kubelet-arg=runtime-cgroups=/systemd/system.slice"
 K3S_ARGS="${K3S_ARGS} --kubelet-arg=kubelet-cgroups=/systemd/system.slice"
 
+if [ "${ROLE}" = "server" ]; then
+  # Use non-default k8s range in case our host is a k8s pod itself
+  # TODO: dynamically check and host ranges
+  K3S_ARGS="${K3S_ARGS} --cluster-cidr=10.128.0.0/16 --service-cidr=10.129.0.0/16"
+fi
+
 echo exec k3s "${ROLE}" ${K3S_ARGS} "$@"
 exec k3s "${ROLE}" ${K3S_ARGS} "$@"
 

--- a/examples/test12-k3s/modes/k3s/compose.yaml
+++ b/examples/test12-k3s/modes/k3s/compose.yaml
@@ -6,9 +6,9 @@ x-network:
     - { service: k3s-agent-1,  bridge: k0, dev: eth1, ip: 10.200.0.2/24 }
     - { service: k3s-agent-2,  bridge: k0, dev: eth1, ip: 10.200.0.3/24 }
     - { service: test-client,  bridge: k0, dev: eth1, ip: 10.200.0.10/24,
-        route: ["10.42.0.0/15 via 10.200.0.2 dev eth1"] }
+        route: ["10.128.0.0/15 via 10.200.0.2 dev eth1"] }
     - { service: test-server,  bridge: k0, dev: eth1, ip: 10.200.0.11/24,
-        route: ["10.42.0.0/15 via 10.200.0.2 dev eth1"] }
+        route: ["10.128.0.0/15 via 10.200.0.2 dev eth1"] }
 
 x-k3s-base: &k3s-base
     depends_on: {extract-utils: {condition: service_completed_successfully}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conlink",
-  "version": "2.5.8",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conlink",
-      "version": "2.5.8",
+      "version": "2.6.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lonocloud/resolve-deps": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conlink",
-  "version": "2.5.8",
+  "version": "2.6.0",
   "description": "conlink -  Declarative Low-Level Networking for Containers",
   "repository": "https://github.com/Viasat/conlink",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
- Support arm64 build in Dockerfile and build/push amd64 and arm64 in GHA release step.
- Fix test12 to support k3s version 1.35
- Move test12 default range to reduce change of collision when running k3s on k8s.